### PR TITLE
Skopeo

### DIFF
--- a/roles/docker-registry-setup/defaults/main.yml
+++ b/roles/docker-registry-setup/defaults/main.yml
@@ -57,6 +57,9 @@ docker_registry_setup_container_image_utility: skopeo
 docker_registry_setup_ports:
   - "{{ docker_registry_setup_local_port }}/tcp"
 
+# whether to verify tls certs on skopeo copy for local registry
+docker_registry_setup_tls_verify: false
+
 # Container images to populate in registry. This list by default only lists the OpenStack container images needed to deploy an OverCloud, but any images could be listed here, as long as they are found on the CDN
 # This list was taken from the yaml that `openstack overcloud container image prepare` command outputs. As that file contains several variables used in the deployment, several of the container images are the same, thus causing duplicates. This list has been cleaned up of all dupes.
 docker_registry_setup_container_images:

--- a/roles/docker-registry-setup/tasks/main.yml
+++ b/roles/docker-registry-setup/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-# just for testing
-- import_tasks: sync.yml
-- pause:
-
 # This task checks for any images on the local registry
 - import_tasks: check.yml
   become: true
@@ -26,14 +22,14 @@
     - docker_registry_setup_on_undercloud | default(False) | bool == True
   become: true
 
-# Download images from upstream registry and push them to local registry (non-Undercloud)
+# Download images from upstream registry and push them to local non-Undercloud registry
 - import_tasks: sync.yml
   when:
     - docker_registry_setup_on_undercloud | default(False) | bool == False
     - docker_registry_setup_sync | default(True) | bool == True
   become: true
 
-# Same thing but for Undercloud
+# Download images from upstream registry and push them to local Undercloud registry
 - import_tasks: undercloud/sync.yml
   when:
     - docker_registry_setup_on_undercloud | default(False) | bool == True

--- a/roles/docker-registry-setup/tasks/sync.yml
+++ b/roles/docker-registry-setup/tasks/sync.yml
@@ -6,7 +6,7 @@
 
 - name: retrieve container image metadata from upstream registry
   command: "skopeo inspect docker://{{ docker_registry_setup_upstream_hostname }}:{{ docker_registry_setup_upstream_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ image.imagename }}"
-  loop: "{{ docker_registry_setup_container_images_test }}"
+  loop: "{{ docker_registry_setup_container_images }}"
   loop_control:
     loop_var: image
   register: container_image_metadata

--- a/roles/docker-registry-setup/tasks/sync.yml
+++ b/roles/docker-registry-setup/tasks/sync.yml
@@ -14,7 +14,7 @@
 - name: show discovered tags for image
   debug:
     msg: "Discovered tags for image='{{ metadata.image.imagename }}' tags='{{ (metadata.stdout | from_json).RepoTags }}'"
-   verbosity: 1
+    verbosity: 1
   loop: "{{ container_image_metadata.results }}"
   loop_control:
     loop_var: metadata

--- a/roles/docker-registry-setup/tasks/sync.yml
+++ b/roles/docker-registry-setup/tasks/sync.yml
@@ -5,10 +5,11 @@
     state: present
 
 - name: retrieve container image metadata from upstream registry
-  command: "skopeo inspect docker://{{ docker_registry_setup_upstream_hostname }}:{{ docker_registry_setup_upstream_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ image.imagename }}"
+  command: skopeo inspect docker://{{ docker_registry_setup_upstream_hostname }}:{{ docker_registry_setup_upstream_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ image.imagename }}
   loop: "{{ docker_registry_setup_container_images }}"
   loop_control:
     loop_var: image
+    label: "{{ image.imagename }}"
   register: container_image_metadata
 
 - name: show discovered tags for image

--- a/roles/docker-registry-setup/tasks/sync.yml
+++ b/roles/docker-registry-setup/tasks/sync.yml
@@ -10,62 +10,19 @@
   loop_control:
     loop_var: image
   register: container_image_metadata
-  no_log: true
 
-- debug:
-    msg: "image='{{ image.image.imagename }}' tags='{{ (image.stdout | from_json).RepoTags }}'"
+- name: show discovered tags for image
+  debug:
+    msg: "Discovered tags for image='{{ metadata.image.imagename }}' tags='{{ (metadata.stdout | from_json).RepoTags }}'"
+   verbosity: 1
   loop: "{{ container_image_metadata.results }}"
   loop_control:
-    loop_var: image
-    label: "{{ (image.stdout | from_json).RepoTags }}"
+    loop_var: metadata
+    label: "{{ (metadata.stdout | from_json).RepoTags }}"
 
 - include_tasks: sync_by_tag.yml
   loop: "{{ container_image_metadata.results }}"
   loop_control:
     loop_var: metadata
     label: "{{ (metadata.stdout | from_json).RepoTags }}"
-
-- pause:
-
-- name: pull images from upstream registry
-  command: "docker pull --all-tags {{ docker_registry_setup_upstream_hostname }}:{{ docker_registry_setup_upstream_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ image.imagename }}"
-  loop: "{{ docker_registry_setup_container_images }}"
-  loop_control:
-    loop_var: image
-
-- name: tag retrieved images for local registry
-  command: "docker tag {{ docker_registry_setup_upstream_hostname }}:{{ docker_registry_setup_upstream_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ image.imagename }} {{ docker_registry_setup_local_hostname }}:{{ docker_registry_setup_local_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ image.imagename }}:{{ docker_registry_setup_image_tag }}"
-  loop: "{{ docker_registry_setup_container_images }}"
-  loop_control:
-    loop_var: image
-
-- name: push docker images from local cache to local registry
-  command: "docker push {{ docker_registry_setup_local_hostname }}:{{ docker_registry_setup_local_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ image.imagename }}:{{ docker_registry_setup_image_tag }}"
-  loop: "{{ docker_registry_setup_container_images }}"
-  loop_control:
-    loop_var: image
-
-# The following task DOES work, but we found that we need to pull all tags which requires the CLI
-#- name: pull docker images
-#  docker_image: 
-#    name: "{{ image.imagename }}"
-#    state: present
-#    pull: true
-#    push: false
-#  loop: "{{ docker_registry_setup_container_images }}"
-#  loop_control:
-#    loop_var: image
-
-# The following task is more desireable as it uses the docker_image module, but I could not get it working in a short time so for now implementing via docker cli
-#- name: push docker images
-#  docker_image: 
-#    name: "{{ docker_registry_setup_image_prefix }}{{ image.imagename }}"
-#    repository: "{{ docker_registry_setup_local_hostname }}:{{ docker_registry_setup_local_port }}/{{ docker_registry_setup_image_namespace }}"
-#    state: present
-#    docker_host: "tcp://{{ inventory_hostname }}:{{ docker_registry_setup_local_port }}"
-#    pull: false
-#    push: true
-#  loop: "{{ docker_registry_setup_container_images }}"
-#  loop_control:
-#    loop_var: image
 ...

--- a/roles/docker-registry-setup/tasks/sync_by_tag.yml
+++ b/roles/docker-registry-setup/tasks/sync_by_tag.yml
@@ -19,4 +19,4 @@
   register: copy_result
   retries: 10
   delay: 5
-  until: copy_result | success
+  until: copy_result is success

--- a/roles/docker-registry-setup/tasks/sync_by_tag.yml
+++ b/roles/docker-registry-setup/tasks/sync_by_tag.yml
@@ -10,7 +10,7 @@
 
 - name: sync image by tag from upstream to local registry
   command: >
-    skopeo --tls-verify=false copy 
+    skopeo --tls-verify={{ docker_registry_setup_tls_verify }} copy 
       docker://{{ docker_registry_setup_upstream_hostname }}:{{ docker_registry_setup_upstream_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }}
       docker://{{ docker_registry_setup_local_hostname }}:{{ docker_registry_setup_local_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }}
   loop: "{{ (metadata.stdout | from_json).RepoTags }}"

--- a/roles/docker-registry-setup/tasks/sync_by_tag.yml
+++ b/roles/docker-registry-setup/tasks/sync_by_tag.yml
@@ -9,7 +9,7 @@
     label: "{{ tag }}"
 
 - name: sync image by tag from upstream to local registry
-  command: "skopeo copy docker://{{ docker_registry_setup_upstream_hostname }}:{{ docker_registry_setup_upstream_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }} {{ docker_registry_setup_local_hostname }}:{{ docker_registry_setup_local_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }}"
+  command: "skopeo --tls-verify=false copy docker://{{ docker_registry_setup_upstream_hostname }}:{{ docker_registry_setup_upstream_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }} {{ docker_registry_setup_local_hostname }}:{{ docker_registry_setup_local_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }}"
   loop: "{{ (metadata.stdout | from_json).RepoTags }}"
   loop_control:
     loop_var: tag

--- a/roles/docker-registry-setup/tasks/sync_by_tag.yml
+++ b/roles/docker-registry-setup/tasks/sync_by_tag.yml
@@ -9,7 +9,10 @@
     label: "{{ tag }}"
 
 - name: sync image by tag from upstream to local registry
-  command: "skopeo --tls-verify=false copy docker://{{ docker_registry_setup_upstream_hostname }}:{{ docker_registry_setup_upstream_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }} {{ docker_registry_setup_local_hostname }}:{{ docker_registry_setup_local_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }}"
+  command: >
+    skopeo --tls-verify=false copy 
+      docker://{{ docker_registry_setup_upstream_hostname }}:{{ docker_registry_setup_upstream_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }}
+      docker://{{ docker_registry_setup_local_hostname }}:{{ docker_registry_setup_local_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }}
   loop: "{{ (metadata.stdout | from_json).RepoTags }}"
   loop_control:
     loop_var: tag

--- a/roles/docker-registry-setup/tasks/sync_by_tag.yml
+++ b/roles/docker-registry-setup/tasks/sync_by_tag.yml
@@ -1,8 +1,16 @@
 ---
-- debug:
+- name: show tag to operate on for image
+  debug:
     msg: "running sync for image='{{ metadata.image.imagename }}' tag='{{ tag }}'"
+    verbosity: 1
   loop: "{{ (metadata.stdout | from_json).RepoTags }}"
   loop_control:
     loop_var: tag
     label: "{{ tag }}"
-...
+
+- name: sync image by tag from upstream to local registry
+  command: "skopeo copy docker://{{ docker_registry_setup_upstream_hostname }}:{{ docker_registry_setup_upstream_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }} {{ docker_registry_setup_local_hostname }}:{{ docker_registry_setup_local_port }}/{{ docker_registry_setup_image_namespace }}/{{ docker_registry_setup_image_prefix }}{{ metadata.image.imagename }}:{{ tag }}"
+  loop: "{{ (metadata.stdout | from_json).RepoTags }}"
+  loop_control:
+    loop_var: tag
+    label: "{{ tag }}"

--- a/roles/docker-registry-setup/tasks/sync_by_tag.yml
+++ b/roles/docker-registry-setup/tasks/sync_by_tag.yml
@@ -16,4 +16,7 @@
   loop: "{{ (metadata.stdout | from_json).RepoTags }}"
   loop_control:
     loop_var: tag
-    label: "{{ tag }}"
+  register: copy_result
+  retries: 10
+  delay: 5
+  until: copy_result | success

--- a/roles/docker-registry-setup/tasks/sync_by_tag.yml
+++ b/roles/docker-registry-setup/tasks/sync_by_tag.yml
@@ -1,7 +1,7 @@
 ---
 - name: show tag to operate on for image
   debug:
-    msg: "running sync for image='{{ metadata.image.imagename }}' tag='{{ tag }}'"
+    msg: "found tag='{{ tag }}' for image='{{ metadata.image.imagename }}'"
     verbosity: 1
   loop: "{{ (metadata.stdout | from_json).RepoTags }}"
   loop_control:


### PR DESCRIPTION
Convert from docker cli pull/tag/push into a single skopeo copy. However, this means a task loops through and calls an inner task that loops through all tags for each image to copy.  In my testing I hit a very intermittent network issue where one specific skopeo copy on a tag failed. I re-ran the command manually and it worked. So I added an until loop to this inner loop, meaning there are now 3 levels of loops.

I'd like to add a feature to only copy specific tags, perhaps a list of tags can be defined by the user (e.g. **tags_to_copy: ['latest','12.0']**). For now it will copy all tags which takes a while.